### PR TITLE
add 32-bit UEFI for 64-bit CPU target

### DIFF
--- a/build/scripts/lib/image.sh
+++ b/build/scripts/lib/image.sh
@@ -231,6 +231,7 @@ rm -rf /localdeb"
         amd64)   _boot_efi="BOOTX64.EFI" ;;
         arm64)   _boot_efi="BOOTAA64.EFI" ;;
         riscv64) _boot_efi="BOOTRISCV64.EFI" ;;
+        i386)    _boot_efi="BOOTIA32.EFI" ;;
     esac
 
     log_step "Building standalone EFI bootloader ($_efi_target)..."
@@ -261,6 +262,13 @@ EOF
                 --output="$_basedir/image_tree/scratch/$_boot_efi" \
                 --locales="" --fonts="" \
                 "boot/grub/grub.cfg=$_basedir/image_tree/scratch/raw_embedded_grub.cfg"
+            if [ -d /usr/lib/grub/i386-efi ]; then
+                grub-mkstandalone \
+                    --format=i386-efi \
+                    --output="$_basedir/image_tree/scratch/BOOTIA32.EFI" \
+                    --locales="" --fonts="" \
+                    "boot/grub/grub.cfg=$_basedir/image_tree/scratch/raw_embedded_grub.cfg"
+            fi
             ;;
         arm64|riscv64)
             sudo mkdir -p "$_mnt/scratch"
@@ -278,6 +286,9 @@ EOF
 
     sudo mkdir -p "$_mnt/boot/efi/EFI/BOOT"
     sudo cp "$_basedir/image_tree/scratch/$_boot_efi" "$_mnt/boot/efi/EFI/BOOT/$_boot_efi"
+    if [ "$_arch" = "amd64" ] && [ -f "$_basedir/image_tree/scratch/BOOTIA32.EFI" ]; then
+        sudo cp "$_basedir/image_tree/scratch/BOOTIA32.EFI" "$_mnt/boot/efi/EFI/BOOT/BOOTIA32.EFI"
+    fi
 
     # Remove the /EFI/debian/ tree that grub-efi-amd64's postinst dropped.
     # Keeping it around lets OVMF persist a Boot#### entry pointing at
@@ -420,6 +431,15 @@ EOF
             --locales="" \
             --fonts="" \
             "boot/grub/grub.cfg=$_basedir/image_tree/scratch/grub.cfg"
+        if [ -d /usr/lib/grub/i386-efi ]; then
+            log_step "Building 32-bit EFI bootloader (i386-efi)..."
+            grub-mkstandalone \
+                --format=i386-efi \
+                --output="$_basedir/image_tree/scratch/bootia32.efi" \
+                --locales="" \
+                --fonts="" \
+                "boot/grub/grub.cfg=$_basedir/image_tree/scratch/grub.cfg"
+        fi
     else
         sudo mkdir -p "$_basedir/image_tree/chroot/scratch"
         sudo cp "$_basedir/image_tree/scratch/grub.cfg" "$_basedir/image_tree/chroot/scratch/"
@@ -440,6 +460,9 @@ EOF
     sudo mkfs.vfat efiboot.img
     mmd -i efiboot.img efi efi/boot
     mcopy -i efiboot.img "./$_efi_name" ::efi/boot/
+    if [ "$_arch" = "amd64" ] && [ -f "./bootia32.efi" ]; then
+        mcopy -i efiboot.img "./bootia32.efi" ::efi/boot/
+    fi
 
     if [ "$_arch" = "amd64" ]; then
         log_step "Building legacy BIOS bootloader..."

--- a/build/scripts/lib/packages.sh
+++ b/build/scripts/lib/packages.sh
@@ -10,7 +10,7 @@ get_base_packages() {
                 " procps vim-tiny libbinutils openssh-server locales xfsprogs" \
                 " fortune-mod ncurses-bin rsync" \
                 " pipewire-audio pipewire-bin wireplumber" \
-                " grub-common grub-efi-amd64-bin grub-pc-bin"
+                " grub-common grub-efi-amd64-bin grub-efi-ia32-bin grub-pc-bin"
             ;;
         arm64)
             printf '%s' \
@@ -121,7 +121,7 @@ get_raw_image_packages() {
             printf '%s' \
                 "systemd systemd-sysv sudo vim net-tools iproute2 openssh-server" \
                 " linux-image-rt-amd64 grub-common grub2-common grub-efi-amd64" \
-                " grub-efi-amd64-bin grub-pc-bin xfsprogs"
+                " grub-efi-amd64-bin grub-efi-ia32 grub-efi-ia32-bin grub-pc-bin xfsprogs"
             ;;
         arm64)
             printf '%s' \


### PR DESCRIPTION
this change will give a chance for Intel CPU Bay Trail/Cherry Trail for boot up.
This commit has ben tested on Lenovo Ideapad Flex 10.

### Proposed changes:
- insert `grub-efi-ia32` and `grub-ia-32-bin` for `amd64` CPU target in `packages.sh`
- insert `bootia32.efi` for `amd64` CPU target in `image.sh`