### PR TITLE
Fix replicants: make application binaries loadable as add-ons

### DIFF
--- a/build/engine.cmake
+++ b/build/engine.cmake
@@ -174,6 +174,19 @@ macro( Application name )
 
 	set_target_properties(${name} PROPERTIES COMPILE_FLAGS "-include LinuxBuildCompatibility.h")
 
+	# Replicants: BShelf revives an archived BView by dlopen()ing the donor
+	# application and resolving its instantiation function (the load_add_on
+	# path of instantiate_object). Applications therefore must export their
+	# symbols, and must stay dlopen-able: glibc refuses any object whose
+	# DT_FLAGS_1 carries DF_1_PIE, so that marker is cleared after linking
+	# (the kernel ignores it; execve/ASLR are unaffected). This also covers
+	# the dual-mode translator TODO above.
+	target_link_options(${name} PRIVATE "-Wl,--export-dynamic")
+	add_custom_command(TARGET ${name} POST_BUILD
+		COMMAND python3 "${CMAKE_SOURCE_DIR}/build/scripts/clear_df1_pie.py" "$<TARGET_FILE:${name}>"
+		COMMENT "Clearing DF_1_PIE on ${name}"
+	)
+
 	foreach( RDEF_FILE ${_APPLICATION_RDEF} )
 		CompileRdef(${name} ${RDEF_FILE} STAGING)
 	endforeach()

--- a/build/scripts/clear_df1_pie.py
+++ b/build/scripts/clear_df1_pie.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# Author: Vláďa Janeček <vlada@janecek.cloud>
+#
+# Clear the DF_1_PIE marker from an ELF executable's DT_FLAGS_1 entry.
+#
+# Replicants (and BeOS dual-mode binaries in general) require dlopen()ing
+# application binaries: BShelf revives an archived BView by loading the
+# donor application and resolving its instantiation function, exactly as
+# load_add_on() does on Haiku. glibc (>= 2.30) refuses to dlopen any
+# object whose DT_FLAGS_1 carries DF_1_PIE ("cannot dynamically load
+# position-independent executable"), even though a PIE binary is already
+# a perfectly relocatable ET_DYN shared object. The check tests only this
+# marker, so clearing it makes the binary dlopen-able again while leaving
+# execve(), ASLR and debugging untouched — the kernel never reads the flag.
+#
+# The file is patched in place. A binary without PT_DYNAMIC, DT_FLAGS_1 or
+# the DF_1_PIE bit is left as is (exit 0), so the tool is safe to run on
+# every linked target.
+
+import struct
+import sys
+
+DF_1_PIE = 0x08000000
+DT_NULL = 0
+DT_FLAGS_1 = 0x6FFFFFFB
+PT_DYNAMIC = 2
+
+
+def fail(msg):
+    print(f"clear_df1_pie: {msg}", file=sys.stderr)
+    return 1
+
+
+def main():
+    if len(sys.argv) != 2:
+        return fail("usage: clear_df1_pie.py <elf-binary>")
+    path = sys.argv[1]
+
+    with open(path, "r+b") as f:
+        ident = f.read(16)
+        if len(ident) != 16 or ident[:4] != b"\x7fELF":
+            return fail(f"{path}: not an ELF file")
+        ei_class, ei_data = ident[4], ident[5]
+        if ei_class != 2:
+            return fail(f"{path}: only ELF64 is supported")
+        endian = "<" if ei_data == 1 else ">"
+
+        # Elf64_Ehdr tail: type, machine, version, entry, phoff, shoff,
+        # flags, ehsize, phentsize, phnum, shentsize, shnum, shstrndx
+        ehdr = struct.unpack(endian + "HHIQQQIHHHHHH", f.read(48))
+        e_phoff, e_phentsize, e_phnum = ehdr[4], ehdr[8], ehdr[9]
+
+        # Find PT_DYNAMIC among the program headers.
+        dyn_off = dyn_size = None
+        for i in range(e_phnum):
+            f.seek(e_phoff + i * e_phentsize)
+            p_type, p_flags, p_offset, p_vaddr, p_paddr, p_filesz = \
+                struct.unpack(endian + "IIQQQQ", f.read(40))
+            if p_type == PT_DYNAMIC:
+                dyn_off, dyn_size = p_offset, p_filesz
+                break
+        if dyn_off is None:
+            return 0  # static or unusual binary: nothing to do
+
+        # Walk Elf64_Dyn entries until DT_NULL, patch DT_FLAGS_1 in place.
+        for off in range(dyn_off, dyn_off + dyn_size, 16):
+            f.seek(off)
+            d_tag, d_val = struct.unpack(endian + "qQ", f.read(16))
+            if d_tag == DT_NULL:
+                break
+            if d_tag == DT_FLAGS_1 and (d_val & DF_1_PIE):
+                f.seek(off + 8)
+                f.write(struct.pack(endian + "Q", d_val & ~DF_1_PIE))
+                break
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/system/libroot2/image.cpp
+++ b/src/system/libroot2/image.cpp
@@ -29,6 +29,13 @@ struct FindByBaseState {
 	int32		current;
 };
 
+struct FindNameState {
+	int32		target;
+	int32		current;
+	bool		found;
+	char		name[B_PATH_NAME_LENGTH];
+};
+
 
 class ImagePool {
 public:
@@ -85,6 +92,8 @@ public:
 
 		void* handle = _Find(id);
 		if (handle == NULL)
+			handle = _OpenEnumerated(id);
+		if (handle == NULL)
 			return B_ERROR;
 
 		void* symbol = dlsym(handle, name);
@@ -106,6 +115,54 @@ private:
 		return it->second;
 	}
 
+	// Resolve a handle for an image that was enumerated via
+	// get_next_image_info() but never went through load_add_on(): the
+	// running program itself, libbe, and every other already-mapped
+	// library. IDs share one numbering (dl_iterate_phdr index + 1) with
+	// Load(), so the index can be walked directly. The image is already
+	// mapped, hence RTLD_NOLOAD only bumps a refcount; handles are cached
+	// and never dlclose()d — these images belong to the process, not to
+	// the add-on pool (Unload() intentionally cannot reach them). This is
+	// what instantiate_object() relies on when reviving archived views:
+	// the in-team pass walks all images looking for the instantiation
+	// function, including classes living in libbe or the app binary.
+	static void* _OpenEnumerated(image_id id) {
+		auto it = fEnumerated.find(id);
+		if (it != fEnumerated.end())
+			return it->second;
+
+		FindNameState state = {(int32)id - 1, 0, false, {0}};
+		dl_iterate_phdr([](struct dl_phdr_info* phdr, size_t size,
+				void* data) -> int {
+			FindNameState* s = (FindNameState*)data;
+			if (s->current != s->target) {
+				s->current++;
+				return 0;
+			}
+			if (phdr->dlpi_name != NULL)
+				strlcpy(s->name, phdr->dlpi_name, sizeof(s->name));
+			s->found = true;
+			return 1;
+		}, &state);
+
+		if (!state.found)
+			return NULL;
+
+		void* handle;
+		if (state.name[0] == '\0') {
+			// The main program: dlopen(NULL) hands out its global handle.
+			handle = dlopen(NULL, RTLD_LAZY);
+		} else {
+			// Anything else (the vdso, for one) that RTLD_NOLOAD cannot
+			// open simply has no reachable symbols; callers iterate on.
+			handle = dlopen(state.name, RTLD_LAZY | RTLD_NOLOAD);
+		}
+
+		if (handle != NULL)
+			fEnumerated[id] = handle;
+		return handle;
+	}
+
 	static image_id _FindIndexByBase(ElfW(Addr) base) {
 		FindByBaseState state = {base, -1, 0};
 		dl_iterate_phdr([](struct dl_phdr_info* phdr, size_t size,
@@ -124,11 +181,13 @@ private:
 	}
 
 	static std::map<image_id, void*> fLoadedAddOns;
+	static std::map<image_id, void*> fEnumerated;
 	static pthread_mutex_t fLock;
 };
 
 
 std::map<image_id, void*> ImagePool::fLoadedAddOns;
+std::map<image_id, void*> ImagePool::fEnumerated;
 pthread_mutex_t ImagePool::fLock = PTHREAD_MUTEX_INITIALIZER;
 
 


### PR DESCRIPTION
Fixes #205, where the diagnosis was "likely some image related bug" — that turned out to be right, with three separate causes in the path `BShelf::AddReplicant()` → `instantiate_object()` → in-team symbol scan → `load_add_on()` of the donor application.

**1. glibc refuses to dlopen our application binaries.** They are linked PIE, so `DT_FLAGS_1` carries `DF_1_PIE`:

```
$ readelf -d /system/apps/ProcessController | grep FLAGS_1
 0x000000006ffffffb (FLAGS_1)   Flags: NOW PIE
$ python3 -c "import ctypes; ctypes.CDLL('/system/apps/ProcessController')"
OSError: cannot dynamically load position-independent executable
```

That marker is the only thing glibc tests and the kernel ignores it, so it is now cleared after linking (`build/scripts/clear_df1_pie.py`, run as a POST_BUILD step). The binaries stay ordinary PIE executables — `execve()`, ASLR and debugging are unaffected — but they are loadable again. This also removes the obstacle described in the dual-mode translator TODO above `Application()`.

**2. Applications exported no symbols**, so `dlsym()` had nothing to find even once the image was open — `.dynsym` contained no `Instantiate` entry at all. Hence `-Wl,--export-dynamic` for `Application()` targets. `Server()` is deliberately left alone; nothing dlopens a server, and `app_server` keeps its `DF_1_PIE` marker.

**3. `get_image_symbol()` and `get_next_image_info()` disagreed about `image_id`.** In `src/system/libroot2/image.cpp` the enumeration numbers images by `dl_iterate_phdr()` index while `ImagePool::FindSymbol()` only knew ids handed out by `load_add_on()`, so the in-team scan `instantiate_object()` starts with could never succeed — which also matters for classes living in libbe when a view hierarchy is unarchived. Both now share one numbering, and enumerated images resolve through `RTLD_NOLOAD` (or the global handle for the program itself). Those handles are cached and never closed: they belong to the process, not to the add-on pool, so `unload_add_on()` intentionally cannot reach them.

### Verification

On a freshly booted image, `ProcessController -deskbar` now installs its replicant in the Deskbar tray:

![Replicant in the Deskbar tray](https://raw.githubusercontent.com/schotek/Vitruvian/screenshots/replicant-tray-zoom.png)

![Desktop after installing the replicant](https://raw.githubusercontent.com/schotek/Vitruvian/screenshots/replicant-desktop.png)

- `BDeskbar::CountItems()` goes 0 → 1 and `HasItem("ProcessController")` becomes true
- a second install is correctly refused as a duplicate
- the icon returns from the saved settings after Deskbar is restarted (screenshot above is taken after such a restart)
- full rebuild of the tree passes, and the desktop (Tracker, Deskbar, Vitrine, freshly linked applications) behaves normally

Intermediate steps were verified in isolation too: `load_add_on()` on an application binary succeeds, `get_image_symbol()` finds `instantiate_deskbar_item`, `instantiate_object()` revives the archived view, and the in-team scan locates the mangled `Instantiate` symbol in the application image.

### Not included

Two adjacent defects surfaced during debugging and are filed separately rather than mixed into this change: stale service data in the launch roster (any `BDeskbar` call fails after Deskbar restarts) and `BRoster::GetAppInfo(signature)` returning `B_OK` with `team = -1, port = -1`.
