### PR TITLE
libroot2: implement get_cpuid so AboutSystem shows the real CPU model

### DIFF
--- a/src/system/libroot2/compat/system_info.cpp
+++ b/src/system/libroot2/compat/system_info.cpp
@@ -11,6 +11,10 @@
 
 #include <algorithm>
 
+#if defined(__x86_64__) || defined(__i386__)
+#include <cpuid.h>
+#endif
+
 #include <syscalls.h>
 #include <system_info.h>
 
@@ -172,7 +176,16 @@ _get_cpu_info_etc(uint32 firstCPU, uint32 cpuCount, cpu_info* info,
 status_t
 get_cpuid(cpuid_info *info, uint32 eaxRegister, uint32 cpuNum)
 {
-	//return _kern_get_cpuid(info, eaxRegister, cpuNum);
+	if (info == NULL)
+		return B_BAD_VALUE;
+
+	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+	__cpuid_count(eaxRegister, 0, eax, ebx, ecx, edx);
+
+	info->regs.eax = eax;
+	info->regs.ebx = ebx;
+	info->regs.ecx = ecx;
+	info->regs.edx = edx;
 	return B_OK;
 }
 #endif

--- a/src/system/libroot2/system_info.c
+++ b/src/system/libroot2/system_info.c
@@ -15,6 +15,10 @@
 #include <sys/utsname.h>
 #include <time.h>
 
+#if defined(__i386__) || defined(__x86_64__)
+#include <cpuid.h>
+#endif
+
 
 extern int32 __gCPUCount;
 
@@ -381,6 +385,18 @@ read_cpu_freq(void)
 }
 
 
+static uint32
+read_cpu_signature(void)
+{
+#if defined(__i386__) || defined(__x86_64__)
+	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+	if (__get_cpuid(1, &eax, &ebx, &ecx, &edx))
+		return (uint32)eax;
+#endif
+	return 0;
+}
+
+
 static enum cpu_vendor
 read_cpu_vendor(void)
 {
@@ -468,11 +484,12 @@ _kern_get_cpu_topology_info(cpu_topology_node_info* topologyInfos,
 		index++;
 	}
 
+	uint32 cpuSignature = read_cpu_signature();
 	for (uint32 i = 0; i < coreCount && index < nodeCount; i++, index++) {
 		topologyInfos[index].id = index;
 		topologyInfos[index].type = B_TOPOLOGY_CORE;
 		topologyInfos[index].level = 2;
-		topologyInfos[index].data.core.model = 0;
+		topologyInfos[index].data.core.model = cpuSignature;
 		topologyInfos[index].data.core.default_frequency = freqHz;
 	}
 


### PR DESCRIPTION
Fixes #230

`get_cpuid()` returned `B_OK` while leaving the output buffer untouched, so AboutSystem's `get_cpuid_model_string()` read uninitialized stack memory — the About window showed random glyphs instead of the CPU model.

- Implement `get_cpuid()` in userspace with `__cpuid_count()` — the instruction is unprivileged, no kernel support needed. Registers are filled by name: the BeOS `cpuid_info` struct deliberately orders them eax/ebx/edx/ecx so `eax_0.vendor_id` reads contiguously, and member-wise assignment keeps that intact.
- Report the real leaf-1 eax signature in `cpu_topology_node_info.data.core.model` (previously hardcoded 0). It is the exact bit layout `get_cpu_model_string()` decodes, so known CPUs resolve through the family/model tables and brand-string parsing becomes the fallback it was meant to be. Non-x86 keeps reporting 0 as before.

Verified live in QEMU/KVM (screenshots in the issue): "Intel `<glyph>` @ 2.42 GHz" → "Intel 11th Gen Core™ i5-1135G7 @ 2.42 GHz".
