### PR TITLE
ssh: generate host keys during install

### DIFF
--- a/data/libexec/vos-install-helper
+++ b/data/libexec/vos-install-helper
@@ -225,6 +225,14 @@ _do_config() {
     rm -f "$TARGET/var/lib/dbus/machine-id"
     systemd-machine-id-setup --root="$TARGET"
 
+    # Create host keys
+    mkdir -p "$TARGET/etc/ssh"
+    ssh-keygen -A -f "$TARGET" || log "warn: ssh-keygen -A returned an error"
+    # ssh-keygen -A exits 0 even when every key write failed, so verify
+    if [ ! -f "$TARGET/etc/ssh/ssh_host_ed25519_key" ]; then
+        log "warn: no sshd host keys in $TARGET/etc/sshd sshd will not start"
+    fi
+
     _target_uuid="$(blkid -s UUID -o value "$_target_source" || true)"
     if [ -z "$_target_uuid" ]; then
         log "cannot resolve target UUID"

--- a/data/systemd/vos-sshdebug.service
+++ b/data/systemd/vos-sshdebug.service
@@ -10,8 +10,8 @@ After=network.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# Install drops /etc/ssh/ssh_host_* (excludes.list), so the target has no host
-# keys and sshd refuses to start. Generate the missing ones first.
+# vos-install-helper generates host keys on the target at install time, so
+# this is a fallback for keys removed since
 ExecStartPre=/usr/bin/ssh-keygen -A
 ExecStart=/usr/bin/systemctl start ssh.service
 


### PR DESCRIPTION
SSH keys should be generated during install so that sshd and friends can work out of the box.

This fixes #235