### PR TITLE
xdg: set the per-user base directories at $HOME/config

### DIFF
--- a/build/profiles/data.cmake
+++ b/build/profiles/data.cmake
@@ -92,7 +92,7 @@ install(FILES "data/artwork/V_OS logo.png" DESTINATION "/system/data/artwork")
 # Profile, inputrc, and profile.d scripts for Terminal
 ImageIncludeFile("data/etc/profile" "/system/settings/etc")
 ImageIncludeFile("data/etc/inputrc" "/system/settings/etc")
-ImageIncludeDir("data/etc/profile.d" "/system/settings/etc/")
+ImageIncludeDir("data/etc/profile.d" "/system/data/")
 
 # Skel: copied into each user's ~/config by useradd -m.
 ImageIncludeFile("data/config/boot/UserBootscript" "/etc/skel/config/settings/boot")

--- a/data/debian/postinst
+++ b/data/debian/postinst
@@ -54,7 +54,7 @@ mkdir -p /system/data/deskbar/menu/Preferences/
 
 mkdir -p /system/boot/post_install/
 mkdir -p /system/boot/first_login/
-mkdir -p /system/settings/etc/profile.d/
+mkdir -p /system/data/profile.d/
 
 mkdir -p "/etc/skel/config/settings/Tracker/Tracker New Templates"
 mkdir -p /etc/skel/config/settings/printers/Preview

--- a/data/etc/profile.d/xdg_basedirs.sh
+++ b/data/etc/profile.d/xdg_basedirs.sh
@@ -1,29 +1,30 @@
 #
-# Haiku setup for
+# Vitruvian setup for the
 # XDG Base Directory Specification
 #
 # http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+#
+# Sourced by /system/settings/etc/profile for login shells: Terminal, SSH, etc.
+
 
 # defaults to ~/.config
-export XDG_CONFIG_HOME="`finddir B_USER_SETTINGS_DIRECTORY`"
+_vos_dir="`finddir B_USER_SETTINGS_DIRECTORY 2>/dev/null`"
+[ -n "$_vos_dir" ] && export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$_vos_dir}"
 
 # defaults to ~/.local/share
-export XDG_DATA_HOME="`finddir B_USER_NONPACKAGED_DATA_DIRECTORY`"
-
-# defaults to /etc/xdg
-export XDG_CONFIG_DIRS="`finddir B_SYSTEM_SETTINGS_DIRECTORY`"
-# XXX: Should we add B_USER_ETC_DIRECTORY?
-
-# default to /usr/local/share/:/usr/share/
-export XDG_DATA_DIRS="`finddir B_SYSTEM_NONPACKAGED_DATA_DIRECTORY`:\
-`finddir B_SYSTEM_DATA_DIRECTORY`"
+_vos_dir="`finddir B_USER_DATA_DIRECTORY 2>/dev/null`"
+[ -n "$_vos_dir" ] && export XDG_DATA_HOME="${XDG_DATA_HOME:-$_vos_dir}"
 
 # defaults to ~/.cache
-export XDG_CACHE_HOME="`finddir B_USER_CACHE_DIRECTORY`"
+_vos_dir="`finddir B_USER_CACHE_DIRECTORY 2>/dev/null`"
+[ -n "$_vos_dir" ] && export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$_vos_dir}"
 
-# TODO:
-# This one is used for session stuff (sockets, pipes...)
-# It must be owned by the user, with permissions 0700.
-# It is supposed to be cleaned up on last log-out.
-# Apps will fall back to /tmp usually anyway.
-#export XDG_RUNTIME_DIR="`finddir B_USER_VAR_DIRECTORY`/tmp"
+# defaults to /etc/xdg
+_vos_dir="`finddir B_SYSTEM_SETTINGS_DIRECTORY 2>/dev/null`"
+[ -n "$_vos_dir" ] && export XDG_CONFIG_DIRS="${XDG_CONFIG_DIRS:-$_vos_dir:/etc/xdg}"
+
+# defaults to /usr/local/share/:/usr/share/
+_vos_dir="`finddir B_SYSTEM_DATA_DIRECTORY 2>/dev/null`"
+[ -n "$_vos_dir" ] && export XDG_DATA_DIRS="${XDG_DATA_DIRS:-$_vos_dir:/usr/local/share:/usr/share}"
+
+unset _vos_dir

--- a/data/libexec/vos-firstboot-commit
+++ b/data/libexec/vos-firstboot-commit
@@ -213,10 +213,17 @@ else
 fi
 
 if command -v xdg-user-dirs-update >/dev/null 2>&1; then
-    $IN runuser -u "$username" -- xdg-user-dirs-update 2>/dev/null || \
-        echo "xdg-user-dirs-update failed" >&2
+    _xdg_home=$($IN getent passwd "$username" | cut -d: -f6)
+    if [ -n "$_xdg_home" ]; then
+        $IN runuser -u "$username" -- \
+            env XDG_CONFIG_HOME="$_xdg_home/config/settings" \
+            xdg-user-dirs-update 2>/dev/null || \
+            echo "xdg-user-dirs-update failed" >&2
+    else
+        echo "cannot resolve home for $username, skipping xdg-user-dirs" >&2
+    fi
 else
-    echo "xdg-user-dirs not installed; skipping" >&2
+    echo "xdg-user-dirs not installed, skipping" >&2
 fi
 
 {

--- a/src/kits/tracker/FSUtils.cpp
+++ b/src/kits/tracker/FSUtils.cpp
@@ -2752,23 +2752,36 @@ CalcItemsAndSize(CopyLoopControl* loopControl,
 
 
 // XDG Trash spec routing for the home volume.
-// Real trash lives at ~/.local/share/Trash/{files,info}. No filesystem
-// trickery on Desktop — the Trash icon is a synthetic pose injected by
-// BPoseView::CreateTrashPose, and Trash window content is aggregated
-// from every volume via BPoseView::AddTrashPoses (per the XDG spec,
-// each volume has its own trash; the UI unifies them).
+// Real trash lives at $XDG_DATA_HOME/Trash/{files,info}, defaulting to
+// ~/.local/share when that is unset. No filesystem trickery on Desktop —
+// the Trash icon is a synthetic pose injected by BPoseView::CreateTrashPose,
+// and Trash window content is aggregated from every volume via
+// BPoseView::AddTrashPoses (per the XDG spec, each volume has its own
+// trash; the UI unifies them).
 //
 // Other volumes (external mounts): <mount>/.Trash-<uid>/files/.
 
 static status_t
 _get_home_trash_dir(BDirectory* trashDir)
 {
-	const char* home = getenv("HOME");
-	if (home == NULL || home[0] != '/')
+	// The spec puts the home trash under $XDG_DATA_HOME, which janus points
+	// at $HOME/config/data. Fall back to the spec default when it is unset,
+	// so Tracker, trash(1) and gio all agree.
+	BPath dataHome;
+	const char* xdgDataHome = getenv("XDG_DATA_HOME");
+	if (xdgDataHome != NULL && xdgDataHome[0] == '/')
+		dataHome.SetTo(xdgDataHome);
+	else {
+		const char* home = getenv("HOME");
+		if (home == NULL || home[0] != '/')
+			return B_ENTRY_NOT_FOUND;
+		dataHome.SetTo(home, ".local/share");
+	}
+	if (dataHome.InitCheck() != B_OK)
 		return B_ENTRY_NOT_FOUND;
 
-	BPath filesDir(home, ".local/share/Trash/files");
-	BPath infoDir(home, ".local/share/Trash/info");
+	BPath filesDir(dataHome.Path(), "Trash/files");
+	BPath infoDir(dataHome.Path(), "Trash/info");
 
 	if (create_directory(filesDir.Path(), 0700) != B_OK)
 		return B_IO_ERROR;

--- a/src/servers/janus/janus.cpp
+++ b/src/servers/janus/janus.cpp
@@ -705,6 +705,24 @@ handle_launch_job(BPrivate::KMessage& kmsg, uid_t sender_uid)
 		setenv("XDG_DATA_DIRS",   "/system/data:/usr/local/share:/usr/share", 0);
 		setenv("XDG_CONFIG_DIRS", "/system/settings:/etc/xdg",                0);
 
+		// Per-user base dirs follow the BeOS layout ($HOME/config/...) instead
+		// of ~/.config, ~/.local/share and ~/.cache. Login shells derive the
+		// same values through finddir in profile.d/xdg_basedirs.sh.
+		// Overwrite 0 like the *_DIRS above, so anything already
+		// in the environment wins.
+		if (sUserHome[0] != '\0') {
+			// PATH_MAX + slack: sUserHome is itself PATH_MAX, so the
+			// suffixes below would trip -Wformat-truncation otherwise.
+			char xdgPath[PATH_MAX + 32];
+			snprintf(xdgPath, sizeof(xdgPath), "%s/config/settings",
+				sUserHome);
+			setenv("XDG_CONFIG_HOME", xdgPath, 0);
+			snprintf(xdgPath, sizeof(xdgPath), "%s/config/data", sUserHome);
+			setenv("XDG_DATA_HOME", xdgPath, 0);
+			snprintf(xdgPath, sizeof(xdgPath), "%s/config/cache", sUserHome);
+			setenv("XDG_CACHE_HOME", xdgPath, 0);
+		}
+
 		if (sUserUid != (uid_t)-1) {
 			char runtimeDir[64];
 			snprintf(runtimeDir, sizeof(runtimeDir), "/run/user/%u",

--- a/src/system/libroot2/fs/find_directory.cpp
+++ b/src/system/libroot2/fs/find_directory.cpp
@@ -339,13 +339,15 @@ __find_directory(directory_which which, dev_t device, bool createIt,
 				templatePath = "$h/Desktop";
 			break;
 		case B_TRASH_DIRECTORY:
-			// XDG Trash spec. Home volume → $h/.local/share/Trash/files.
+			// XDG Trash spec. Home volume → $d/Trash/files, where $d is
+			// XDG_DATA_HOME. Tracker resolves the same way, and the two must
+			// agree.
 			// FAT (legacy) → RECYCLED/_BEOS_. Other external volumes are
 			// routed by FSGetTrashDir via MountInfo to <mount>/.Trash-<uid>/
 			// files (this template stays NULL so callers that ask without
 			// volume context get -ENOENT, matching Haiku).
 			if (device == bootDevice || !strcmp(fsInfo.fsh_name, "bfs"))
-				templatePath = "$h/.local/share/Trash/files";
+				templatePath = "$d/Trash/files";
 			else if (!strcmp(fsInfo.fsh_name, "fat"))
 				templatePath = "RECYCLED/_BEOS_";
 			break;
@@ -481,11 +483,25 @@ __find_directory(directory_which which, dev_t device, bool createIt,
 
 	PathBuffer pathBuffer(buffer, pathLength, strlen(buffer));
 
-	// resolve "$h" placeholder to the user's home directory
-	if (!strncmp(templatePath, "$h", 2)) {
-		// B_TRASH_DIRECTORY is per-user, not per-volume.
-		if (which != B_TRASH_DIRECTORY
-			&& bootDevice != B_INVALID_DEV && device != bootDevice) {
+	// resolve "$d" placeholder to XDG_DATA_HOME keeping trash(1), Tracker and
+	// gio pointed at one directory
+	if (!strncmp(templatePath, "$d", 2)) {
+		const char* dataHome = getenv("XDG_DATA_HOME");
+		if (dataHome != NULL && dataHome[0] == '/') {
+			size_t length = strlcpy(buffer, dataHome, pathLength);
+			if (length >= pathLength)
+				return -E2BIG;
+			pathBuffer.SetTo(buffer, pathLength, length);
+		} else {
+			size_t length = get_user_home_path(buffer, pathLength);
+			if (length >= pathLength)
+				return -E2BIG;
+			pathBuffer.SetTo(buffer, pathLength, length);
+			pathBuffer.Append("/.local/share");
+		}
+		templatePath += 2;
+	} else if (!strncmp(templatePath, "$h", 2)) {
+		if (bootDevice != B_INVALID_DEV && device != bootDevice) {
 			pathBuffer.Append("/home");
 		} else {
 			size_t length = get_user_home_path(buffer, pathLength);


### PR DESCRIPTION
xdg_basedirs.sh maps the XDG base directories, but nothing actually runs it, and several different components use a different directory layout.

This fixes all that by:
- Moving xdg_basedirs.sh to where it will be found
- Fixes in the script to not look for the nonexistant NONPACKAGED constants
- Move the Trash location in Tracker, trahs(1), and gio
- Have janus use the same XDG layout
- Set XDG_CONFIG_HOME in vos-firstboot-commit

Fixes #237 