### PR TITLE
Fix slider scaling and crash

### DIFF
--- a/build/profiles/debug.cmake
+++ b/build/profiles/debug.cmake
@@ -63,6 +63,31 @@ set(TEST_LIBROOT_BINARIES
 	system_watching_test
 )
 
+# Interface kit manual tests. LookTest and ControlLookTest are widget
+# galleries, the rest are drawing, input and timer checks that happen to
+# live alongside them.
+set(TEST_GUI_BINARIES
+	LookTest
+	ControlLookTest
+	ChannelSliderTest
+	ListViewTest
+	MenuBeginningTest
+	ScrollViewTest
+	SimpleAlertTest
+	SliderTest
+	StatusBarTest
+	TextViewTestManual
+	ToolTipTest
+	WindowStackTest
+	ClippingPlusRedraw
+	DrawBitmapTest
+	GetMouseTest
+	PulseTest
+	ScreenTest
+	SetDiskModeTest
+	TruncateString
+)
+
 set(TEST_ADDONS
 	supporttest
 	storagetest
@@ -73,6 +98,7 @@ set(TEST_ADDONS
 )
 
 ImageInclude("/system/tests" ${TEST_BINARIES} ${TEST_VOS_BINARIES} ${TEST_KERNEL_BINARIES} ${TEST_LIBROOT_BINARIES} cppunit)
+ImageInclude("/system/tests/interface" ${TEST_GUI_BINARIES})
 ImageInclude("/system/tests/lib" ${TEST_ADDONS})
 ImageIncludeFile("src/tests/runsuite.sh" "/system/tests")
 ImageIncludeDir("src/tests/kits/storage/resources" "/system/tests")

--- a/src/kits/interface/HaikuControlLook.cpp
+++ b/src/kits/interface/HaikuControlLook.cpp
@@ -370,7 +370,7 @@ HaikuControlLook::DrawStatusBar(BView* view, BRect& rect, const BRect& updateRec
 	if (!ShouldDraw(view, rect, updateRect))
 		return;
 
-	_DrawOuterResessedFrame(view, rect, base, 0.6);
+	_DrawOuterResessedFrame(view, rect, tint_color(base, 0.6));
 
 	// colors
 	rgb_color dark1BorderColor = tint_color(base, 1.3);
@@ -464,6 +464,7 @@ HaikuControlLook::DrawCheckBox(BView* view, BRect& rect, const BRect& updateRect
 
 	rgb_color markColor;
 	if (_RadioButtonAndCheckBoxMarkColor(base, markColor, flags)) {
+		view->PushState();
 		view->SetHighColor(markColor);
 
 		BFont font;
@@ -491,6 +492,7 @@ HaikuControlLook::DrawCheckBox(BView* view, BRect& rect, const BRect& updateRect
 			view->StrokeLine(rect.LeftTop(), rect.RightBottom());
 			view->StrokeLine(rect.LeftBottom(), rect.RightTop());
 		}
+		view->PopState();
 	}
 }
 
@@ -1557,6 +1559,10 @@ HaikuControlLook::DrawSliderHashMarks(BView* view, BRect& rect,
 		startPos = rect.top + 1;
 	}
 
+	// scale the mark lengths from the default font size
+	const float markLength = ceilf(4 * std::max(1.0f,
+		be_plain_font->Size() / 12.0f));
+
 	if (location & B_HASH_MARKS_TOP) {
 		view->BeginLineArray(hashMarkCount * 2);
 
@@ -1564,9 +1570,9 @@ HaikuControlLook::DrawSliderHashMarks(BView* view, BRect& rect,
 			float pos = startPos;
 			for (int32 i = 0; i < hashMarkCount; i++) {
 				view->AddLine(BPoint(pos, rect.top),
-							  BPoint(pos, rect.top + 4), darkColor);
+							  BPoint(pos, rect.top + markLength), darkColor);
 				view->AddLine(BPoint(pos + 1, rect.top),
-							  BPoint(pos + 1, rect.top + 4), lightColor);
+							  BPoint(pos + 1, rect.top + markLength), lightColor);
 
 				pos += factor;
 			}
@@ -1574,9 +1580,9 @@ HaikuControlLook::DrawSliderHashMarks(BView* view, BRect& rect,
 			float pos = startPos;
 			for (int32 i = 0; i < hashMarkCount; i++) {
 				view->AddLine(BPoint(rect.left, pos),
-							  BPoint(rect.left + 4, pos), darkColor);
+							  BPoint(rect.left + markLength, pos), darkColor);
 				view->AddLine(BPoint(rect.left, pos + 1),
-							  BPoint(rect.left + 4, pos + 1), lightColor);
+							  BPoint(rect.left + markLength, pos + 1), lightColor);
 
 				pos += factor;
 			}
@@ -1591,9 +1597,9 @@ HaikuControlLook::DrawSliderHashMarks(BView* view, BRect& rect,
 		if (orientation == B_HORIZONTAL) {
 			float pos = startPos;
 			for (int32 i = 0; i < hashMarkCount; i++) {
-				view->AddLine(BPoint(pos, rect.bottom - 4),
+				view->AddLine(BPoint(pos, rect.bottom - markLength),
 							  BPoint(pos, rect.bottom), darkColor);
-				view->AddLine(BPoint(pos + 1, rect.bottom - 4),
+				view->AddLine(BPoint(pos + 1, rect.bottom - markLength),
 							  BPoint(pos + 1, rect.bottom), lightColor);
 
 				pos += factor;
@@ -1601,9 +1607,9 @@ HaikuControlLook::DrawSliderHashMarks(BView* view, BRect& rect,
 		} else {
 			float pos = startPos;
 			for (int32 i = 0; i < hashMarkCount; i++) {
-				view->AddLine(BPoint(rect.right - 4, pos),
+				view->AddLine(BPoint(rect.right - markLength, pos),
 							  BPoint(rect.right, pos), darkColor);
-				view->AddLine(BPoint(rect.right - 4, pos + 1),
+				view->AddLine(BPoint(rect.right - markLength, pos + 1),
 							  BPoint(rect.right, pos + 1), lightColor);
 
 				pos += factor;

--- a/src/kits/interface/Slider.cpp
+++ b/src/kits/interface/Slider.cpp
@@ -20,6 +20,7 @@
 #include <Bitmap.h>
 #include <ControlLook.h>
 #include <Errors.h>
+#include <Font.h>
 #include <LayoutUtils.h>
 #include <Message.h>
 #include <Region.h>
@@ -31,6 +32,25 @@
 
 #define USE_OFF_SCREEN_VIEW 0
 
+
+//	The default font size is 12, so everything should scale realtive to that.
+static float
+scaled(float value)
+{
+	return ceilf(value * std::max(1.0f, be_plain_font->Size() / 12.0f));
+}
+
+static float
+thumb_inset(thumb_style style)
+{
+	return style == B_BLOCK_THUMB ? scaled(8.0) : scaled(7.0);
+}
+
+static float
+thumb_length(thumb_style style)
+{
+	return style == B_BLOCK_THUMB ? scaled(17.0) : scaled(12.0);
+}
 
 BSlider::BSlider(
 	BRect frame, const char* name, const char* label, BMessage* message,
@@ -219,7 +239,6 @@ BSlider::_InitBarColor()
 {
 	SetBarColor(be_control_look->SliderBarColor(
 		ui_color(B_PANEL_BACKGROUND_COLOR)));
-	fFillColor = BarColor();
 	UseFillColor(false, NULL);
 }
 
@@ -1039,12 +1058,13 @@ BSlider::UpdateTextChanged()
 	if (fUpdateText != NULL)
 		oldWidth = StringWidth(fUpdateText);
 
-	const char* oldUpdateText = fUpdateText;
+	bool hadUpdateText = fUpdateText != NULL;
 	free(fUpdateText);
 
-	fUpdateText = strdup(UpdateText());
-	bool updateTextOnOff = (fUpdateText == NULL && oldUpdateText != NULL)
-		|| (fUpdateText != NULL && oldUpdateText == NULL);
+	const char* updateText = UpdateText();
+	fUpdateText = updateText != NULL ? strdup(updateText) : NULL;
+
+	bool updateTextOnOff = (bool)fUpdateText ^ hadUpdateText;
 
 	float newWidth = 0.0;
 	if (fUpdateText != NULL)
@@ -1091,19 +1111,18 @@ BSlider::BarFrame() const
 	float textHeight = ceilf(fontHeight.ascent) + ceilf(fontHeight.descent);
 	float leading = ceilf(fontHeight.leading);
 
-	float thumbInset;
-	if (fStyle == B_BLOCK_THUMB)
-		thumbInset = 8.0;
-	else
-		thumbInset = 7.0;
+	const float thumbInset = thumb_inset(fStyle);
+
+	const float barThickness = scaled(fBarThickness);
 
 	if (Orientation() == B_HORIZONTAL) {
 		frame.left = thumbInset;
-		frame.top = 6.0 + (Label() || fUpdateText ? textHeight + 4.0 : 0.0);
+		frame.top = scaled(6.0)
+			+ (Label() || fUpdateText ? textHeight + scaled(4.0) : 0.0);
 		frame.right -= thumbInset;
-		frame.bottom = frame.top + fBarThickness;
+		frame.bottom = frame.top + barThickness;
 	} else {
-		frame.left = floorf((frame.Width() - fBarThickness) / 2.0);
+		frame.left = floorf((frame.Width() - barThickness) / 2.0);
 		frame.top = thumbInset;
 		if (Label() != NULL)
 			frame.top += textHeight;
@@ -1114,7 +1133,7 @@ BSlider::BarFrame() const
 				frame.top += leading;
 		}
 
-		frame.right = frame.left + fBarThickness;
+		frame.right = frame.left + barThickness;
 		frame.bottom = frame.bottom - thumbInset;
 		if (fMinLimitLabel != NULL)
 			frame.bottom -= textHeight;
@@ -1136,11 +1155,11 @@ BSlider::HashMarksFrame() const
 	BRect frame(BarFrame());
 
 	if (fOrientation == B_HORIZONTAL) {
-		frame.top -= 6.0;
-		frame.bottom += 6.0;
+		frame.top -= scaled(6.0);
+		frame.bottom += scaled(6.0);
 	} else {
-		frame.left -= 6.0;
-		frame.right += 6.0;
+		frame.left -= scaled(6.0);
+		frame.right += scaled(6.0);
 	}
 
 	return frame;
@@ -1150,44 +1169,38 @@ BSlider::HashMarksFrame() const
 BRect
 BSlider::ThumbFrame() const
 {
-	// TODO: The slider looks really ugly and broken when it is too little.
-	// I would suggest using BarFrame() here to get the top and bottom coords
-	// and spread them further apart for the thumb
+	// Everything here is relative to the bar, so that the math is clearer.
+	const BRect bar = BarFrame();
+	BRect frame = bar;
 
-	BRect frame = Bounds();
-
-	font_height fontHeight;
-	GetFontHeight(&fontHeight);
-
-	float textHeight = ceilf(fontHeight.ascent) + ceilf(fontHeight.descent);
+	const float position = floorf(Position()
+		* (_MaxPosition() - _MinPosition()) + _MinPosition());
 
 	if (fStyle == B_BLOCK_THUMB) {
+		// the block straddles the bar, overhanging it on both sides
 		if (Orientation() == B_HORIZONTAL) {
-			frame.left = floorf(Position() * (_MaxPosition()
-				- _MinPosition()) + _MinPosition()) - 8;
-			frame.top = 2 + (Label() || fUpdateText ? textHeight + 4 : 0);
-			frame.right = frame.left + 17;
-			frame.bottom = frame.top + fBarThickness + 7;
+			frame.top = bar.top - scaled(4);
+			frame.bottom = bar.bottom + scaled(3);
+			frame.left = position - scaled(8);
+			frame.right = frame.left + thumb_length(fStyle);
 		} else {
-			frame.left = floor((frame.Width() - fBarThickness) / 2) - 4;
-			frame.top = floorf(Position() * (_MaxPosition()
-				- _MinPosition()) + _MinPosition()) - 8;
-			frame.right = frame.left + fBarThickness + 7;
-			frame.bottom = frame.top + 17;
+			frame.left = bar.left - scaled(4);
+			frame.right = bar.right + scaled(3);
+			frame.top = position - scaled(8);
+			frame.bottom = frame.top + thumb_length(fStyle);
 		}
 	} else {
+		// the triangle hangs off the far edge of the bar
 		if (Orientation() == B_HORIZONTAL) {
-			frame.left = floorf(Position() * (_MaxPosition()
-				- _MinPosition()) + _MinPosition()) - 6;
-			frame.right = frame.left + 12;
-			frame.top = 3 + fBarThickness + (Label() ? textHeight + 4 : 0);
-			frame.bottom = frame.top + 8;
+			frame.top = bar.bottom - scaled(3);
+			frame.bottom = frame.top + scaled(8);
+			frame.left = position - scaled(6);
+			frame.right = frame.left + thumb_length(fStyle);
 		} else {
-			frame.left = floorf((frame.Width() + fBarThickness) / 2) - 3;
-			frame.top = floorf(Position() * (_MaxPosition()
-				- _MinPosition())) + _MinPosition() - 6;
-			frame.right = frame.left + 8;
-			frame.bottom = frame.top + 12;
+			frame.left = bar.right - scaled(3);
+			frame.right = frame.left + scaled(8);
+			frame.top = position - scaled(6);
+			frame.bottom = frame.top + thumb_length(fStyle);
 		}
 	}
 
@@ -1661,8 +1674,12 @@ BSlider::_ValidateMinSize()
 	if (fMaxUpdateTextWidth < 0.0f)
 		fMaxUpdateTextWidth = MaxUpdateTextWidth();
 
+	// minAlongAxis has to be big enough to hold both bar insets
+	const float minAlongAxis = 2 * thumb_inset(fStyle)
+		+ 2 * thumb_length(fStyle);
+
 	if (Orientation() == B_HORIZONTAL) {
-		height = 12.0f + fBarThickness;
+		height = scaled(12.0f + fBarThickness);
 		int32 rows = 0;
 
 		float labelWidth = 0;
@@ -1695,18 +1712,18 @@ BSlider::_ValidateMinSize()
 		if (labelWidth > width)
 			width = labelWidth;
 
-		if (width < 32.0f)
-			width = 32.0f;
+		if (width < minAlongAxis)
+			width = minAlongAxis;
 
 		if (MinLimitLabel() || MaxLimitLabel())
 			rows++;
 
 		height += rows * (ceilf(fontHeight.ascent)
-			+ ceilf(fontHeight.descent) + 4.0);
+			+ ceilf(fontHeight.descent) + scaled(4.0));
 	} else {
 		// B_VERTICAL
-		width = 12.0f + fBarThickness;
-		height = 32.0f;
+		width = scaled(12.0f + fBarThickness);
+		height = minAlongAxis;
 
 		float lineHeightNoLeading = ceilf(fontHeight.ascent)
 			+ ceilf(fontHeight.descent);

--- a/src/tests/kits/interface/SliderTest.cpp
+++ b/src/tests/kits/interface/SliderTest.cpp
@@ -3,13 +3,38 @@
  * Distributed under the terms of the MIT License.
  */
 
-
+#include "InterfaceDefs.h"
 #include <Application.h>
-#include <Window.h>
+#include <ControlLook.h>
+#include <GridLayout.h>
+#include <GroupLayoutBuilder.h>
+#include <GroupLayout.h>
+#include <LayoutBuilder.h>
 #include <Slider.h>
+#include <SpaceLayoutItem.h>
 #include <StringView.h>
+#include <Window.h>
 
 #include <stdio.h>
+
+// Slider with update text but no label has a broken triangle thumb.
+class UpdateTextSlider : public BSlider {
+	public:
+		UpdateTextSlider(const char* name, thumb_style thumbType)
+			: BSlider(name, NULL, NULL, 0, 100, B_HORIZONTAL, thumbType)
+		{
+			SetValue(50);
+		}
+
+		virtual const char* UpdateText() const
+		{
+			snprintf(fText, sizeof(fText), "%" B_PRId32, Value());
+			return fText;
+		}
+
+	private:
+		mutable char fText[16];
+};
 
 
 class Window : public BWindow {
@@ -20,129 +45,108 @@ class Window : public BWindow {
 };
 
 
-void
-downBy(BRect &rect, BView* view)
-{
-	rect.bottom = rect.top + view->Bounds().Height() + 10;
-	rect.OffsetBy(0, rect.Height());
-}
-
-
-void
-rightBy(BRect &rect, BView* view)
-{
-	rect.right = rect.left + view->Bounds().Width() + 10;
-	rect.OffsetBy(rect.Width(), 0);
-}
-
-
 //	#pragma mark -
 
 
 Window::Window()
-	: BWindow(BRect(100, 100, 600, 400), "Slider-Test",
-			B_TITLED_WINDOW, B_ASYNCHRONOUS_CONTROLS)
+	: BWindow(BRect(100, 100, 800, 500),
+	      "Slider-Test", B_DOCUMENT_WINDOW,
+	      B_ASYNCHRONOUS_CONTROLS | B_AUTO_UPDATE_SIZE_LIMITS
+		| B_QUIT_ON_WINDOW_CLOSE)
 {
-	BRect rect = Bounds();
-	BView* view = new BView(rect, NULL, B_FOLLOW_ALL, B_WILL_DRAW);
-	view->SetViewUIColor(B_PANEL_BACKGROUND_COLOR);
-	AddChild(view);
+
+	
+	rgb_color fillColor = { 200, 80, 80, 255 };
 
 	// horizontal sliders
+	BSlider* slider1 = new BSlider("Slider1", "Test 1", NULL, 0, 100, B_HORIZONTAL);
+	BSlider* slider2 = new BSlider("Slider2", "Test 2", NULL, 0, 100, B_HORIZONTAL, B_TRIANGLE_THUMB);
 
-	rect.InsetBy(10, 10);
-	rect.right = rect.left + 250;
-	rect.bottom = rect.top + 30;
+	BSlider* slider3 = new BSlider("Slider3", "Test 3", NULL, 0, 100, B_HORIZONTAL);
+	slider3->UseFillColor(true, &fillColor);
+	slider3->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	slider3->SetHashMarkCount(11);
+	slider3->SetLimitLabels("0", "100");
+	slider3->SetBarThickness(12.0);
 
-	BSlider* slider = new BSlider(rect, "Slider1", "Test 1", NULL, 0, 100);
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
+	BSlider* slider4 = new BSlider("Slider4", "Test 4", NULL, 0, 100, B_HORIZONTAL, B_TRIANGLE_THUMB);
+	slider4->SetLimitLabels("0", "100");
+	slider4->UseFillColor(true, &fillColor);
+	slider4->SetBarThickness(20.0);
+	slider4->SetHashMarks(B_HASH_MARKS_BOTH);
+	slider4->SetHashMarkCount(21);
 
-	downBy(rect, slider);
+	BSlider* slider9 = new UpdateTextSlider("Slider9", B_TRIANGLE_THUMB);
+	BSlider* slider10 = new UpdateTextSlider("Slider10", B_BLOCK_THUMB);
 
-	slider = new BSlider(rect, "Slider2", "Test 2", NULL, 0, 100, B_TRIANGLE_THUMB);
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
-	
-	downBy(rect, slider);
-
-	slider = new BSlider(rect, "Slider3", "Test 3", NULL, 0, 100);
-	rgb_color color = { 200, 80, 80, 255 };
-	slider->UseFillColor(true, &color);
-	slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
-	slider->SetHashMarkCount(11);
-	slider->SetLimitLabels("0", "100");
-	slider->SetBarThickness(12.0);
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
-
-	downBy(rect, slider);
-
-	slider = new BSlider(rect, "Slider4", "Test 4", NULL, 0, 100, B_TRIANGLE_THUMB);
-	slider->SetLimitLabels("0", "100");
-	slider->UseFillColor(true, &color);
-	slider->SetBarThickness(20.0);
-	slider->SetHashMarks(B_HASH_MARKS_BOTH);
-	slider->SetHashMarkCount(21);
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
-
-	downBy(rect, slider);
-	rect.right = rect.left + 100;
-	rect.bottom = rect.top + 100;
-
-	slider = new BSlider(rect, "SliderA", "Test A", NULL, 0, 100);
-	slider->SetLimitLabels("0", "100");
-	slider->UseFillColor(true, &color);
-	slider->SetHashMarks(B_HASH_MARKS_BOTH);
-	slider->SetHashMarkCount(5);
-	view->AddChild(slider);
+	BSlider *sliderA = new BSlider("SliderA", "Test A", NULL, 0, 100, B_HORIZONTAL);
+	sliderA->SetLimitLabels("0", "100");
+	sliderA->UseFillColor(true, &fillColor);
+	sliderA->SetHashMarks(B_HASH_MARKS_BOTH);
+	sliderA->SetHashMarkCount(5);
+	sliderA->SetExplicitMaxSize(sliderA->MinSize());
 
 	// vertical sliders
+	BSlider* slider5 = new BSlider("Slider5", "Test 5", NULL, 0, 100, B_VERTICAL);
+	slider5->SetBarThickness(12.0);
+	slider5->SetHashMarks(B_HASH_MARKS_RIGHT);
+	slider5->SetHashMarkCount(5);
 
-	rect.left = 270;
-	rect.right = rect.left + 30;
-	rect.top = 10;
-	rect.bottom = view->Bounds().Height() - 20;
+	BSlider* slider6 = new BSlider("Slider6", "Test 6", NULL, 0, 100, B_VERTICAL, B_TRIANGLE_THUMB);
 
-	slider = new BSlider(rect, "Slider5", "Test 5", NULL, 0, 100);
-	slider->SetOrientation(B_VERTICAL);
-	slider->SetBarThickness(12.0);
-	slider->SetHashMarks(B_HASH_MARKS_RIGHT);
-	slider->SetHashMarkCount(5);
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
+	BSlider* slider7 = new BSlider("Slider7", "Test 7", NULL, 0, 100, B_VERTICAL);
+	slider7->UseFillColor(true, &fillColor);
+	slider7->SetHashMarks(B_HASH_MARKS_BOTH);
+	slider7->SetBarThickness(6.0);
+	slider7->SetHashMarkCount(11);
+	slider7->SetLimitLabels("0", "100");
 
-	rightBy(rect, slider);
-
-	slider = new BSlider(rect, "Slider6", "Test 6", NULL, 0, 100, B_TRIANGLE_THUMB);
-	slider->SetOrientation(B_VERTICAL);
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
+	BSlider* slider8 = new BSlider("Slider8", "Test 8", NULL, 0, 100, B_VERTICAL, B_TRIANGLE_THUMB);
+	slider8->SetOrientation(B_VERTICAL);
+	slider8->UseFillColor(true, &fillColor);
+	slider8->SetBarThickness(20.0);
+	slider8->SetHashMarks(B_HASH_MARKS_BOTH);
+	slider8->SetHashMarkCount(21);
+	slider8->SetLimitLabels("0", "100");
 	
-	rightBy(rect, slider);
+	BSlider *sliderB = new BSlider("SliderB", "Test B", NULL, 0, 100, B_VERTICAL);
+	sliderB->SetLimitLabels("0", "100");
+	sliderB->UseFillColor(true, &fillColor);
+	sliderB->SetHashMarks(B_HASH_MARKS_BOTH);
+	sliderB->SetHashMarkCount(5);
+	sliderB->SetExplicitMaxSize(sliderB->MinSize());
 
-	slider = new BSlider(rect, "Slider7", "Test 7", NULL, 0, 100);
-	slider->SetOrientation(B_VERTICAL);
-	slider->UseFillColor(true, &color);
-	slider->SetHashMarks(B_HASH_MARKS_BOTH);
-	slider->SetBarThickness(6.0);
-	slider->SetHashMarkCount(11);
-	slider->SetLimitLabels("0", "100");
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
+	BGroupLayout* h_group =
+		BLayoutBuilder::Group<>(B_VERTICAL)
+			.Add(slider1)
+			.Add(slider2)
+			.Add(slider3)
+			.Add(slider4)
+			.Add(slider9)
+			.Add(slider10)
+			.AddGroup(B_HORIZONTAL)
+				.Add(sliderA)
+				.AddGlue()
+			.End()
+			.AddGlue();
+	BGroupLayout* v_group =
+		BLayoutBuilder::Group<>(B_HORIZONTAL)
+			.Add(slider5)
+			.Add(slider6)
+			.Add(slider7)
+			.Add(slider8)
+			.AddGroup(B_VERTICAL)
+				.Add(sliderB)
+				.AddGlue()
+			.End()
+			.AddGlue();
+	h_group->SetExplicitMinSize(BSize(400, B_SIZE_UNSET));
 
-	rightBy(rect, slider);
 
-	slider = new BSlider(rect, "Slider8", "Test 8", NULL, 0, 100, B_TRIANGLE_THUMB);
-	slider->SetOrientation(B_VERTICAL);
-	slider->UseFillColor(true, &color);
-	slider->SetBarThickness(20.0);
-	slider->SetHashMarks(B_HASH_MARKS_BOTH);
-	slider->SetHashMarkCount(21);
-	slider->SetLimitLabels("0", "100");
-	slider->ResizeToPreferred();
-	view->AddChild(slider);
+	BLayoutBuilder::Group<>(this, B_HORIZONTAL)
+		.SetInsets(BControlLook::ComposeSpacing(B_USE_WINDOW_SPACING))
+		.Add(h_group)
+		.Add(v_group);
 }
 
 


### PR DESCRIPTION
This does three things:
1) Fix slider scaling, which was a mess and only partially worked. 
2) Fix a crash when setting text on a plain BSlider 
3) Add the UI tests to the build and install so it's easer to take a look at them

This fixes #256 