### PR TITLE
Enhance Scanner with foreign mount handling and inode tracking

### DIFF
--- a/src/apps/diskusage/PieView.cpp
+++ b/src/apps/diskusage/PieView.cpp
@@ -455,7 +455,10 @@ PieView::_DrawDirectory(BRect b, FileInfo* info, float parentSpan,
 			// the center circle, with the used segment representing the
 			// volume's root directory.
 			off_t volCapacity = snapshot->capacity;
-			mySpan = 360.0 * (volCapacity - snapshot->freeBytes) / volCapacity;
+			off_t volInUse = volCapacity - snapshot->freeBytes;
+			if (volInUse < 0)
+				volInUse = 0;
+			mySpan = volCapacity > 0 ? 360.0 * volInUse / volCapacity : 0.0;
 
 			SetHighColor(kEmptySpcColor);
 			FillEllipse(BPoint(cx, cy), kPieCenterSize, kPieCenterSize);

--- a/src/apps/diskusage/Scanner.cpp
+++ b/src/apps/diskusage/Scanner.cpp
@@ -10,11 +10,17 @@
 
 #include "Scanner.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 #include <Catalog.h>
 #include <Directory.h>
+#include <Entry.h>
+#include <Path.h>
+
+#include <MountInfo.h>
 
 #include "DiskUsage.h"
 
@@ -22,7 +28,6 @@
 #define B_TRANSLATION_CONTEXT "Scanner"
 
 using std::vector;
-
 
 Scanner::Scanner(BVolume *v, BHandler *handler)
 	:
@@ -144,6 +149,34 @@ void
 Scanner::_RunScan(FileInfo* startInfo)
 {
 	fQuitRequested = false;
+	fVolumeDev = fVolume->Device();
+	fSubmountDevs.clear();
+	fSeenInodes.clear();
+	fVisitedDirs.clear();
+
+	BString rootPath;
+	BPrivate::MountEntry rootMount;
+	if (BPrivate::MountInfo::FindByDev(fVolumeDev, &rootMount))
+		rootPath = rootMount.mount_point;
+
+	BPrivate::MountSnapshot mounts = BPrivate::MountInfo::Snapshot();
+	if (mounts != NULL) {
+		BString prefix(rootPath);
+		if (prefix.Length() > 0 && prefix.ByteAt(prefix.Length() - 1) != '/')
+			prefix << "/";
+		for (size_t i = 0; i < mounts->size(); i++) {
+			const BPrivate::MountEntry& e = (*mounts)[i];
+			if (e.dev == fVolumeDev)
+				continue;
+			if (rootPath.Length() == 0 || rootPath == "/"
+					|| e.mount_point == rootPath
+					|| e.mount_point.StartsWith(prefix.String())) {
+				fSubmountDevs.insert(e.dev);
+			}
+		}
+	}
+
+
 	BString stringScan(B_TRANSLATE("Scanning %refName%"));
 
 	if (startInfo == NULL || startInfo == fSnapshot->rootDir) {
@@ -152,6 +185,8 @@ Scanner::_RunScan(FileInfo* startInfo)
 		stringScan.ReplaceFirst("%refName%", fSnapshot->name.c_str());
 		fTask = stringScan.String();
 		fVolumeBytesInUse = fSnapshot->capacity - fSnapshot->freeBytes;
+		if (fVolumeBytesInUse <= 0)
+			fVolumeBytesInUse = fSnapshot->capacity > 0 ? fSnapshot->capacity : 1;
 		fVolumeBytesScanned = 0;
 		fProgress = 0.0;
 		fLastReport = -1.0;
@@ -185,6 +220,8 @@ Scanner::_RunScan(FileInfo* startInfo)
 		stringScan.ReplaceFirst("%refName%", startInfo->ref.name);
 		fTask = stringScan.String();
 		fVolumeBytesInUse = fSnapshot->capacity - fSnapshot->freeBytes;
+		if (fVolumeBytesInUse <= 0)
+			fVolumeBytesInUse = fSnapshot->capacity > 0 ? fSnapshot->capacity : 1;
 		fVolumeBytesScanned = fVolumeBytesInUse - startInfo->size; //best guess
 		fProgress = fVolumeBytesScanned / fVolumeBytesInUse;
 		fLastReport = -1.0;
@@ -235,25 +272,39 @@ Scanner::_GetFileInfo(BDirectory* dir, FileInfo* parent)
 	thisDir->parent = parent;
 	thisDir->count = 0;
 
+	if (dir->InitCheck() != B_OK)
+		return thisDir;
+
+	struct stat dirStat;
+	if (dir->GetStat(&dirStat) == B_OK)
+		fVisitedDirs.insert(std::make_pair(dirStat.st_dev, dirStat.st_ino));
+
 	while (true) {
 		if (fQuitRequested) {
 			delete thisDir;
 			return NULL;
 		}
 
-		if (dir->GetNextEntry(&entry) == B_ENTRY_NOT_FOUND)
+		if (dir->GetNextEntry(&entry) != B_OK)
 			break;
 		if (entry.IsSymLink())
 			continue;
 
 
 		if (entry.IsFile()) {
-			entry_ref ref;
-			if ((entry.GetRef(&ref) == B_OK) && (ref.device() != Device()))
+			struct stat st;
+			if (entry.GetStat(&st) != B_OK)
 				continue;
+
+			if (st.st_nlink > 1 && !fSeenInodes.insert(
+					std::make_pair(st.st_dev, st.st_ino)).second) {
+				thisDir->count++;
+				continue;
+			}
+
 			FileInfo *child = new FileInfo;
 			entry.GetRef(&child->ref);
-			entry.GetSize(&child->size);
+			child->size = (off_t)st.st_blocks * 512;
 			child->parent = thisDir;
 			child->color = -1;
 			thisDir->children.push_back(child);
@@ -267,8 +318,34 @@ Scanner::_GetFileInfo(BDirectory* dir, FileInfo* parent)
 			}
 		}
 		else if (entry.IsDirectory()) {
+			struct stat st;
+			if (entry.GetStat(&st) != B_OK) {
+				thisDir->count++;
+				continue;
+			}
+
+			if (_IsForeignMount(st.st_dev)) {
+				thisDir->count++;
+				continue;
+			}
+
+			if (!fVisitedDirs.insert(
+					std::make_pair(st.st_dev, st.st_ino)).second) {
+				thisDir->count++;
+				continue;
+			}
 			BDirectory childDir(&entry);
-			thisDir->children.push_back(_GetFileInfo(&childDir, thisDir));
+			if (childDir.InitCheck() != B_OK) {
+				thisDir->count++;
+				continue;
+			}
+			FileInfo* childInfo = _GetFileInfo(&childDir, thisDir);
+			if (childInfo == NULL) {
+
+				delete thisDir;
+				return NULL;
+			}
+			thisDir->children.push_back(childInfo);
 		}
 		thisDir->count++;
 	}
@@ -281,6 +358,14 @@ Scanner::_GetFileInfo(BDirectory* dir, FileInfo* parent)
 	}
 
 	return thisDir;
+}
+
+
+bool
+Scanner::_IsForeignMount(dev_t childDev) const
+{
+	return childDev != fVolumeDev
+		&& fSubmountDevs.find(childDev) != fSubmountDevs.end();
 }
 
 

--- a/src/apps/diskusage/Scanner.h
+++ b/src/apps/diskusage/Scanner.h
@@ -10,11 +10,14 @@
 #define SCANNER_H
 
 
+#include <set>
 #include <string>
+#include <utility>
 
 #include <Looper.h>
 #include <Message.h>
 #include <Messenger.h>
+#include <String.h>
 #include <Volume.h>
 
 #include "Snapshot.h"
@@ -57,6 +60,7 @@ private:
 			void				_ChangeToDesired();
 			bool				_DirectoryContains(FileInfo* currentDir,
 									entry_ref* ref);
+			bool				_IsForeignMount(dev_t childDev) const;
 
 			BMessenger			fListener;
 			BMessage			fDoneMessage;
@@ -72,6 +76,10 @@ private:
 			string				fTask;
 			bool				fBusy;
 			bool				fQuitRequested;
+			dev_t				fVolumeDev;
+			std::set<dev_t>		fSubmountDevs;
+			std::set<std::pair<dev_t, ino_t> > fSeenInodes;
+			std::set<std::pair<dev_t, ino_t> > fVisitedDirs;
 };
 
 #endif // SCANNER_H


### PR DESCRIPTION
The scanning works because the ability to scan the root (/) has been added—unlike with BFS inodes. It also scans filesystems like btrfs that use subvolumes. Here is a small snippet of code that handles subvolumes/volumes based on dev_t (device).